### PR TITLE
fix bug and refactor index coercion

### DIFF
--- a/src/rlf/forecasting/data_fetching_utilities/level_provider/level_provider_nwis.py
+++ b/src/rlf/forecasting/data_fetching_utilities/level_provider/level_provider_nwis.py
@@ -26,7 +26,7 @@ class LevelProviderNWIS(BaseLevelProvider):
         Returns:
             pd.DataFrame: A dataframe of recent level data with a tz aware UTC Datetime index. Guaranteed to have num_hours rows.
         """
-        start_dt = datetime.utcnow() - timedelta(hours=(num_hours+48))
+        start_dt = datetime.utcnow() - timedelta(hours=(num_hours + 48))
         start_str = datetime.strftime(start_dt, '%Y-%m-%d')
         data_all = self.fetch_level(start=start_str)
         data_trimmed = data_all.iloc[-num_hours:, :]
@@ -65,6 +65,6 @@ class LevelProviderNWIS(BaseLevelProvider):
         df.rename(columns=rename_dict, inplace=True)
 
         # Format data
-        df = BaseLevelProvider.format_level_data(df)
+        df = self.format_level_data(df)
 
         return df


### PR DESCRIPTION
This fixes a bug where hours with identical observations were getting dropped. I also refactored the index coercion to take the first observed river level for each hour span.

I don't think it is still possible to have duplicate indices but I left in logic to catch them and drop them regardless.