### PR TITLE
Filter units when rebuilding datums from AWS (fixes #52)

### DIFF
--- a/src/rlf/aws_dispatcher.py
+++ b/src/rlf/aws_dispatcher.py
@@ -137,6 +137,8 @@ class AWSDispatcher():
         try:
             meta_data = self.download_dict_from_json(folder_name, "meta")
             hourly_units = self.download_dict_from_json(folder_name, "units")
+            if columns is not None:
+                hourly_units = dict((key, hourly_units[key]) for key in columns)
             hourly_parameters = self.download_df_from_parquet(folder_name, "data", columns=columns)
         except FileNotFoundError as e:
             print("Error occured while fetching saved datum from AWS for coordinate: " + str(coordinate))


### PR DESCRIPTION
Previously, when selecting a subset of columns from AWS, the units dict would still contain ALL units, not just the subset. This pr filters the hourly_units dict when rebuilding a Datum from AWS data.
fixes #52 