### PR TITLE
Tests updated to use new response args for WeatherDatum (#60 #48)

### DIFF
--- a/tests/forecasting/data_fetching_utilities/weather_provider/test_aws_weather_provider.py
+++ b/tests/forecasting/data_fetching_utilities/weather_provider/test_aws_weather_provider.py
@@ -4,6 +4,9 @@ from rlf.aws_dispatcher import AWSDispatcher
 from rlf.forecasting.data_fetching_utilities.coordinate import Coordinate
 from rlf.forecasting.data_fetching_utilities.weather_provider.aws_weather_provider import AWSWeatherProvider
 
+# It is expected that datums will be stored for this timestamp in the bucket specified for the coordinates specified.
+CURRENT_TESTING_TIMESTAMP = "23-01-31_07-42"
+
 
 @pytest.fixture
 def aws_dispatcher() -> AWSDispatcher:
@@ -32,7 +35,7 @@ def test_fetch_historical(weather_provider):
 
 @pytest.mark.slow
 def test_fetch_current(weather_provider):
-    weather_provider.set_timestamp("23-01-13_14-38")
+    weather_provider.set_timestamp(CURRENT_TESTING_TIMESTAMP)
     weather_datums = weather_provider.fetch_current()
     assert len(weather_datums) == len(weather_provider.coordinates)
     for weather_datum in weather_datums:

--- a/tests/forecasting/data_fetching_utilities/weather_provider/test_datum.py
+++ b/tests/forecasting/data_fetching_utilities/weather_provider/test_datum.py
@@ -25,7 +25,8 @@ def weather_df(num_samples):
 
 @pytest.fixture
 def datum():
-    return WeatherDatum(longitude=0, latitude=0, elevation=0, utc_offset_seconds=0,
+    return WeatherDatum(longitude=0, latitude=0, api_response_longitude=0,
+                        api_response_latitude=0, elevation=0, utc_offset_seconds=0,
                         timezone="Fake Time Zone", hourly_units="Fake Units", hourly_parameters=weather_df(10))
 
 

--- a/tests/forecasting/fake_providers.py
+++ b/tests/forecasting/fake_providers.py
@@ -49,6 +49,8 @@ def weather_datums(num_samples, num_dfs):
         datum = WeatherDatum(
             longitude=i + 0.1,
             latitude=i + 1.1,
+            api_response_longitude=i + 0.1,
+            api_response_latitude=i + 1.1,
             elevation=0.0,
             utc_offset_seconds=0.0,
             timezone=None,


### PR DESCRIPTION
Previous PR broke tons of tests, had to add in the new arg to the constructor in tests.

fixes #60 #48