### PR TITLE
Start and end date handling fixed in AWSWP (fixes #78)

### DIFF
--- a/src/rlf/forecasting/data_fetching_utilities/weather_provider/aws_weather_provider.py
+++ b/src/rlf/forecasting/data_fetching_utilities/weather_provider/aws_weather_provider.py
@@ -72,14 +72,15 @@ class AWSWeatherProvider(BaseWeatherProvider):
         if start_date is not None:
             start_dt = datetime.strptime(
                 start_date, '%Y-%m-%d').replace(tzinfo=pytz.UTC)
-
-            if end_date is not None:
-                end_dt = datetime.strptime(
-                    end_date, '%Y-%m-%d').replace(tzinfo=pytz.UTC)
-                for datum in datums:
-                    datum.hourly_parameters = datum.hourly_parameters[start_dt:end_dt]
-            else:
-                datum.hourly_parameters = datum.hourly_parameters[start_dt:]
+        else:
+            start_dt = None
+        if end_date is not None:
+            end_dt = datetime.strptime(
+                end_date, '%Y-%m-%d').replace(tzinfo=pytz.UTC)
+        else:
+            end_dt = None
+        for datum in datums:
+            datum.hourly_parameters = datum.hourly_parameters[start_dt:end_dt]
 
         return datums
 


### PR DESCRIPTION
Previously failed if end_date supplied but no start_date supplied.

