### PR TITLE
switch to using X and y training set

### DIFF
--- a/src/rlf/forecasting/training_forecaster.py
+++ b/src/rlf/forecasting/training_forecaster.py
@@ -47,7 +47,7 @@ class TrainingForecaster(BaseForecaster):
 
     def fit(self) -> None:
         """Fit the underlying Darts ForecastingModel model."""
-        self.model.fit(self.dataset.y, future_covariates=self.dataset.X)
+        self.model.fit(self.dataset.y_train, future_covariates=self.dataset.X_train)
         self.save_model()
 
     def save_model(self) -> None:


### PR DESCRIPTION
Changes the `TrainingForecaster` to fit to the training datasets. This also improves performance as the model was originally fitting on unscaled data.

Closes #84 