### PR TITLE
TrainingDataset creation moved inside TrainingForecaster init (fixes #92)

### DIFF
--- a/src/rlf/forecasting/training_forecaster.py
+++ b/src/rlf/forecasting/training_forecaster.py
@@ -13,7 +13,6 @@ class TrainingForecaster(BaseForecaster):
     def __init__(
         self,
         model: ForecastingModel,
-        dataset: TrainingDataset,
         catchment_data: CatchmentData,
         root_dir: str = DEFAULT_WORK_DIR,
         filename: str = "frcstr",
@@ -23,7 +22,6 @@ class TrainingForecaster(BaseForecaster):
 
         Args:
             model (ForecastingModel): A darts ForecastingModel to train.
-            dataset (TrainingDataset): Dataset to use for training.
             catchment_data (CatchmentData): CatchmentData instance to use for training.
             root_dir (str, optional): Root dir to store trained model. Defaults to DEFAULT_WORK_DIR.
             filename (str, optional): Filename to use for trained model. Defaults to frcstr.
@@ -36,7 +34,7 @@ class TrainingForecaster(BaseForecaster):
             scaler_filename=scaler_filename)
 
         self.model = model
-        self.dataset = dataset
+        self.dataset = TrainingDataset(catchment_data=catchment_data)
 
         os.makedirs(self.work_dir, exist_ok=True)
         if (os.path.isfile(self.model_save_path)):

--- a/tests/forecasting/test_training_forecaster.py
+++ b/tests/forecasting/test_training_forecaster.py
@@ -17,13 +17,8 @@ def catchment_data():
     return CatchmentData("test_catchment", FakeWeatherProvider(num_historical_samples=1000), FakeLevelProvider(num_historical_samples=1000))
 
 
-@pytest.fixture
-def training_dataset(catchment_data):
-    return TrainingDataset(catchment_data=catchment_data)
-
-
-def test_training_forecaster_init(training_dataset, catchment_data):
-    training_forecaster = TrainingForecaster(model=None, catchment_data=catchment_data, dataset=training_dataset)
+def test_training_forecaster_init(catchment_data):
+    training_forecaster = TrainingForecaster(model=None, catchment_data=catchment_data)
 
     assert (type(training_forecaster.dataset) is TrainingDataset)
 
@@ -31,7 +26,6 @@ def test_training_forecaster_init(training_dataset, catchment_data):
 def test_training_forecaster_save_model(tmp_path, catchment_data):
     training_forecaster = TrainingForecaster(
         RegressionEnsembleModel([LinearRegressionModel(lags=1)], 10),
-        TrainingDataset(catchment_data),
         catchment_data,
         root_dir=tmp_path
     )


### PR DESCRIPTION
In the TrainingForecaster init call, TrainingDataset and CatchmentData are redundant - TrainingDataset just wraps catchment_data.

This PR removes the dataset param, instead initializing a TrainingDataset from within the Forecaster's init method.

The only disadvantage here is that we lose direct access the init args of dataset - if/when we need top level access to this, we could elevate them to params in the forecaster init or pass a kwargs dict through.