### PR TITLE
Pass TrainingDataset to TrainingForecaster

### DIFF
--- a/src/rlf/forecasting/training_forecaster.py
+++ b/src/rlf/forecasting/training_forecaster.py
@@ -2,7 +2,6 @@ from darts.models.forecasting.forecasting_model import ForecastingModel
 import os
 import pickle
 
-from rlf.forecasting.catchment_data import CatchmentData
 from rlf.forecasting.base_forecaster import BaseForecaster, DEFAULT_WORK_DIR
 from rlf.forecasting.training_dataset import TrainingDataset
 
@@ -13,7 +12,7 @@ class TrainingForecaster(BaseForecaster):
     def __init__(
         self,
         model: ForecastingModel,
-        catchment_data: CatchmentData,
+        dataset: TrainingDataset,
         root_dir: str = DEFAULT_WORK_DIR,
         filename: str = "frcstr",
         scaler_filename: str = "scaler",
@@ -22,19 +21,19 @@ class TrainingForecaster(BaseForecaster):
 
         Args:
             model (ForecastingModel): A darts ForecastingModel to train.
-            catchment_data (CatchmentData): CatchmentData instance to use for training.
+            dataset (TrainingDataset): TrainingDataset instance to use for training.
             root_dir (str, optional): Root dir to store trained model. Defaults to DEFAULT_WORK_DIR.
             filename (str, optional): Filename to use for trained model. Defaults to frcstr.
             scaler_filename (str, optional): Filename to use for the scalers. Defaults to "scaler".
         """
         super().__init__(
-            catchment_data=catchment_data,
+            catchment_data=dataset.catchment_data,
             root_dir=root_dir,
             filename=filename,
             scaler_filename=scaler_filename)
 
         self.model = model
-        self.dataset = TrainingDataset(catchment_data=catchment_data)
+        self.dataset = dataset
 
         os.makedirs(self.work_dir, exist_ok=True)
         if (os.path.isfile(self.model_save_path)):

--- a/tests/forecasting/test_training_forecaster.py
+++ b/tests/forecasting/test_training_forecaster.py
@@ -16,17 +16,20 @@ from rlf.forecasting.training_forecaster import TrainingForecaster
 def catchment_data():
     return CatchmentData("test_catchment", FakeWeatherProvider(num_historical_samples=1000), FakeLevelProvider(num_historical_samples=1000))
 
+@pytest.fixture
+def training_dataset(catchment_data):
+    return TrainingDataset(catchment_data)
 
-def test_training_forecaster_init(catchment_data):
-    training_forecaster = TrainingForecaster(model=None, catchment_data=catchment_data)
+def test_training_forecaster_init(training_dataset):
+    training_forecaster = TrainingForecaster(model=None, dataset=training_dataset)
 
     assert (type(training_forecaster.dataset) is TrainingDataset)
 
 
-def test_training_forecaster_save_model(tmp_path, catchment_data):
+def test_training_forecaster_save_model(tmp_path, training_dataset):
     training_forecaster = TrainingForecaster(
         RegressionEnsembleModel([LinearRegressionModel(lags=1)], 10),
-        catchment_data,
+        training_dataset,
         root_dir=tmp_path
     )
 


### PR DESCRIPTION
This mostly reverts the change from #93 and instead of eliminating the `TrainingDataset` parameter it eliminates the `CatchmentData` parameter. This addresses the issue where we couldn't set the engineered columns anymore, and it also unblocks an order of operations issue for predicting column prefixes.

Fixes #98 