### PR TITLE
Add Training Script

### DIFF
--- a/scripts/training/train_model_hpc.py
+++ b/scripts/training/train_model_hpc.py
@@ -42,7 +42,7 @@ usage = """
 
 
 DEFAULT_EPOCHS = 1
-DEFAULT_DATA_FILE = "catchments_high_precision_short.json"
+DEFAULT_DATA_FILE = "catchments_short.json"
 DEFAULT_COLUMNS = [
     "apparent_temperature",
     "cloudcover",


### PR DESCRIPTION
Adding a script that is useful for training models on HPC. You can specify the gauge ID, number of epochs, catchments file, and columns file as command line arguments. At a minimum you have to specify a gauge ID. You must have a catchments geojson file available as well.

To specify a specific set of columns then you must create a text file that has a single column name on each line. For example, a file like this would only pick the three listed columns (if the path is passed to the -c argument):
```
temperature_2m
rain
snow
```

The trained models will be saved to a directory with this path: `./trained_models/{gauge ID}/`
