### PR TITLE
Draft: Fix Level Values

### DIFF
--- a/src/rlf/forecasting/data_fetching_utilities/level_provider/level_provider_nwis.py
+++ b/src/rlf/forecasting/data_fetching_utilities/level_provider/level_provider_nwis.py
@@ -43,7 +43,7 @@ class LevelProviderNWIS(BaseLevelProvider):
         """
         return self.fetch_level()
 
-    def fetch_level(self, start: str = "1900-01-01", end: Optional[str] = None, parameterCd: str = '00065', drop_cols: List[str] = ["00060_cd", "site_no"], rename_dict: dict = {"00065": "level"}) -> pd.DataFrame:
+    def fetch_level(self, start: str = "1900-01-01", end: Optional[str] = None, parameterCd: str = '00065', rename_dict: dict = {"00065": "level"}) -> pd.DataFrame:
         """
         Fetch level data for the given gauge ID. Fetches instant values from start to end.
         Drops and renames columns according to given args.
@@ -51,17 +51,12 @@ class LevelProviderNWIS(BaseLevelProvider):
             start (str, optional): Start date in the form "yyyy-mm-dd". Defaults to "1900-01-01", giving data from start of collection.
             end  (str, optional): End date in the form "yyyy-mm-dd". Defaults to None, giving data til end of collection.
             parameterCd (str, optional): Which parameter to fetch data for. Defaults to '00065' indicated mean level.
-            drop_cols (list, optional): Column names to drop if they are present. Defaults to ["00060_cd", "site_no"] (useless metadata).
-            rename_dict (dict, optional): Dictionary of default:new defining column renamings. Defaults to {"00060":"level"}.
+            rename_dict (dict, optional): Dictionary of default:new defining column renamings. Defaults to {"00065":"level"}.
         Returns:
             df (Pandas dataframe): Formatted dataframe of fetched data
         """
         # Fetch level data
         df = nwis.get_record(sites=self.gauge_id, service='iv', start=start, end=end, parameterCd=parameterCd)
-
-        # Filter out any columns that are present in the drop_cols list
-        drop_cols = list(filter(lambda x: x in df.columns, drop_cols))
-        df.drop(columns=drop_cols, inplace=True)
 
         # Rename columns as specified
         df.rename(columns=rename_dict, inplace=True)


### PR DESCRIPTION
We are currently pulling flow rates from NWIS and not river levels. The parameterCd for river levels is 00065. Here are the docs for these values: https://waterservices.usgs.gov/rest/IV-Service.html#parameterCd

With this change we get numbers like this:
```
                           level
datetime
2023-03-01 01:00:00+00:00   4.60
2023-03-01 02:00:00+00:00   4.63
2023-03-01 03:00:00+00:00   4.64
2023-03-01 04:00:00+00:00   4.68
2023-03-01 05:00:00+00:00   4.68
```

Instead of:
```
                           level
datetime
2023-03-01 02:00:00+00:00  837.0
2023-03-01 03:00:00+00:00  841.0
2023-03-01 04:00:00+00:00  855.0
2023-03-01 05:00:00+00:00  855.0
2023-03-01 06:00:00+00:00  859.0
```

This PR also eliminates the `drop_col` parameter. I feel that it is better to enforce the number of returned columns (1) using an allow list instead of using a block list.