### PR TITLE
Add wrapper for backtest (fixes #122)

### DIFF
--- a/src/rlf/forecasting/training_forecaster.py
+++ b/src/rlf/forecasting/training_forecaster.py
@@ -69,6 +69,8 @@ class TrainingForecaster(BaseForecaster):
             json.dump(metadata, f)
 
     def backtest(self,
+                 run_on_validation: bool = False,
+                 future_covariates: bool = True,
                  retrain: bool = False,
                  start: float = 0.95,
                  forecast_horizon: int = 24,
@@ -78,6 +80,8 @@ class TrainingForecaster(BaseForecaster):
         https://unit8co.github.io/darts/generated_api/darts.models.forecasting.regression_ensemble_model.html#darts.models.forecasting.regression_ensemble_model.RegressionEnsembleModel.backtest
 
         Args:
+            run_on_validation (bool, optional): Whether to run on the validation dataset. Runs on Test set if False. Defaults to False.
+            future_covariates (bool, optional): Whether to pass X as future covariates. X will be passed as past_covariates if False. Defaults to True.
             retrain (bool, optional): Whether to retrain the model on the entire training dataset. Defaults to False.
             start (float, optional): The proportion of the training dataset to use for backtesting. Defaults to 0.95.
             forecast_horizon (int, optional): The forecast horizon to use. Defaults to 24.
@@ -87,8 +91,23 @@ class TrainingForecaster(BaseForecaster):
         Returns:
             float: The backtest score. See darts docs for more details.
         """
-        return self.model.backtest(self.dataset.y_train,
-                                   future_covariates=self.dataset.X_train,
+        if (run_on_validation):
+            x = self.dataset.X_validation
+            y = self.dataset.y_validation
+        else:
+            x = self.dataset.X_test
+            y = self.dataset.y_test
+
+        if (future_covariates):
+            past_covariates = None
+            future_covariates = x
+        else:
+            past_covariates = x
+            future_covariates = None
+
+        return self.model.backtest(y,
+                                   past_covariates=past_covariates,
+                                   future_covariates=future_covariates,
                                    retrain=retrain,
                                    start=start,
                                    forecast_horizon=forecast_horizon,


### PR DESCRIPTION
Basically just wraps: https://unit8co.github.io/darts/generated_api/darts.models.forecasting.regression_ensemble_model.html#darts.models.forecasting.regression_ensemble_model.RegressionEnsembleModel.backtest
