### PR TITLE
Fix rolling avg/sum columns bug

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - pytest                  # Unit testing framework
   - boto3                   # AWS S3 interaction
   - s3fs                    # AWS S3 interaction TODO: Convert to only boto3 OR only s3fs (Issue #30)
-  - holidays=0.24           # Holiday calendar for time series forecasting
+  - holidays=0.24           # Holiday calendar for time series forecasting. Version locked to avoid upstream issue.
   - pytorch=1.13.1          # Core underlying neural network library
   - pytorch-lightning=1.9.3 # High level interface for pytorch
   - u8darts-all=0.23        # Core Timeseries forecasting library

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: rlf-dep-testing
+name: river-level
 channels:
   - conda-forge
   - pytorch

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: river-level-test-2
+name: rlf-dep-testing
 channels:
   - conda-forge
   - pytorch
@@ -13,6 +13,9 @@ dependencies:
   - pytest                  # Unit testing framework
   - boto3                   # AWS S3 interaction
   - s3fs                    # AWS S3 interaction TODO: Convert to only boto3 OR only s3fs (Issue #30)
+  - holidays=0.24           # Holiday calendar for time series forecasting
+  - pytorch=1.13.1          # Core underlying neural network library
+  - pytorch-lightning=1.9.3 # High level interface for pytorch
   - u8darts-all=0.23        # Core Timeseries forecasting library
   - pip                     # Package installer for dependencies not available through Conda
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,6 @@ dependencies:
   - pytest                  # Unit testing framework
   - boto3                   # AWS S3 interaction
   - s3fs                    # AWS S3 interaction TODO: Convert to only boto3 OR only s3fs (Issue #30)
-  - pytorch=1.13.1          # Core underlying neural network library
-  - pytorch-lightning=1.9.3 # High level interface for pytorch
   - u8darts-all=0.23        # Core Timeseries forecasting library
   - pip                     # Package installer for dependencies not available through Conda
   - pip:

--- a/src/rlf/forecasting/base_dataset.py
+++ b/src/rlf/forecasting/base_dataset.py
@@ -58,13 +58,15 @@ class BaseDataset(ABC):
         # find the boundaries that are valid for all datasets
         first_date, last_date = self._find_timestamp_boundaries(Xs, y)
 
-        y = TimeSeries.from_dataframe(y).slice(first_date, last_date)
-
         X_last_date = None if allow_future_X else last_date
         processed_Xs = [self._process_datum(datum, first_date, X_last_date) for datum in Xs]
         X_concatenated = concatenate(processed_Xs, axis="component")
 
+        if X_concatenated.time_index[0] > first_date:
+            first_date = X_concatenated.time_index[0]
         X_concatenated = X_concatenated.astype("float32")
+
+        y = TimeSeries.from_dataframe(y).slice(first_date, last_date)
         y = y.astype("float32")
 
         return X_concatenated, y


### PR DESCRIPTION
Adding these columns would previously throw an error due to the first piece of the time series having NaNs.

An additional check to trim the y data accordingly is introduced. 

Usage of these columns is added into the run_grid_search_job script. 